### PR TITLE
Added in loading when filtering

### DIFF
--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -36,13 +36,17 @@ const ExploreItems = () => {
 
   function filterItems(filter) {
     setLoaded(8)
+    setLoading(true)
 
     if (filter === "price_low_to_high") {
       setItems(items.slice().sort((a, b) => a.price - b.price));
+      setLoading(false)
     } else if (filter === "price_high_to_low") {
       setItems(items.slice().sort((a, b) => b.price - a.price));
+      setLoading(false)
     } else if (filter === "likes_high_to_low") {
       setItems(items.slice().sort((a, b) => b.likes - a.likes));
+      setLoading(false)
     } else if (filter === "") {
       fetchItems()
     }


### PR DESCRIPTION
**Task:**
Make items load when filtering

**Why:**
So if the user has a slow internet connection then they wont be confused if it's taking a little while for it to reorder.

**How:**
Since I already have a useState which sets the loading value incase the client doesnt get the data from the API fast enough then I just set that to true and they will all start loading. And if the client has already loaded them but the image isnt loaded fast enough then I have a check inside the ExploreItem component which only lets the image get put into the DOM if it's fully loaded.